### PR TITLE
Fix #5: Create default services configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,19 @@
 web/build
 web/node_modules
 web/bower_components
-server/.DS_Store
 server/node_modules
 *.iml
 .gradle
 .idea
-/local.properties
-/.idea/workspace.xml
-/.idea/libraries
+.vscode
 .DS_Store
 /build
 /captures
 .externalNativeBuild
+
+# Config files
 config
-server/config
+server/config/index.json
+
+# npm
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ Last October, some friends and I hacked together a software [solution](https://g
 
 1. Clone the project and cd into SJPL-MealTally/server.
 
-2. You will need to either add a ../../config folder with a MongoLabs URI and an email URI OR create two new environment variables:
-  * **MLABURI** = mongodb://\<dbUser\>:\<dbPassword\>@ds0\<port\>.mlab.com:\<port\>/mealtally
-  * **MAILURI** = smtps://\<emailAddress\>:\<password\>@smtp.gmail.com/?pool=true (if you're using gmail, you will have to change some settings - you'll get an email about it the first time you try to run the app with your URI)
-  * NOTE: If you go with the config file option, please make sure to add it to your .gitignore so that your sensitive information is not accidentally posted to github.
+2. You will need to either:
+  * Add these variables with a MongoLabs URI and an email URI into a `server/config/index.json` file.
+    - **MLABURI** = `mongodb://\<dbUser\>:\<dbPassword\>@ds0\<port\>.mlab.com:\<port\>/mealtally`
+    - **MAILURI** = `smtps://\<emailAddress\>:\<password\>@smtp.gmail.com/?pool=true` 
+      * If you're using Gmail, you will have to change some settings - you'll get an email about it the first time you try to run the app with your URI)
+  * OR add those same variables as environmental variables.
 
 3. `npm install`
 
 4. `node app`
 
-The app should connect to the database and be running at localhost:3000
+The app should connect to the database and be running at http://localhost:3000.
 

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,6 +1,0 @@
-web/build
-web/node_modules
-web/bower_components
-server/.DS_Store
-server/node_modules
-config

--- a/server/app.js
+++ b/server/app.js
@@ -1,3 +1,4 @@
+var fs = require('fs');
 var express = require("express");
 var bodyParser = require('body-parser').json();
 var app = express();
@@ -7,8 +8,8 @@ var ObjectId = require('mongodb').ObjectID;
 var cron = require('node-cron');
 var cronTask = require('./modules/cronConfig/cron')
 
-if(!process.env.MLABURI) var config = require('./config/mongo');
-var mongoUrl = process.env.MLABURI || config.mongoURI;
+var config = fs.existsSync('./config/index.json') ? require('./config') : {};
+var mongoUrl = process.env.MLABURI || config.MLABURI;
 
 app.listen(process.env.PORT || 3000);
 console.log("Server running on port 3000");

--- a/server/config/index.json.example
+++ b/server/config/index.json.example
@@ -1,0 +1,4 @@
+{
+    "MLABURI": "",
+    "MAILURI": ""
+}

--- a/server/modules/cronConfig/cron.js
+++ b/server/modules/cronConfig/cron.js
@@ -3,8 +3,8 @@ var convertPDF = require('../pdfConverter/pdfconverter.js');
 var http = require('http');
 var fs = require('fs');
 var nodemailer = require('nodemailer');
-if(!process.env.MAILURI) var config = require('../../config/mail');
-var transporter = nodemailer.createTransport(process.env.MAILURI || config.mail);
+var config = fs.existsSync('../../config/index.json') ? require('../../config') : {};
+var transporter = nodemailer.createTransport(process.env.MAILURI || config.MAILURI);
 
 var cronTask = function() {
   var cronTime = new Date(),


### PR DESCRIPTION
Create a default (example) services configuration file for MongoDB and Gmail.

You can now just place your variables in `config/index.json` for development purposes.  I've updated the README as well to show how it works.

Fixes #5.