### PR TITLE
Remove `cordova.js` script tag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,9 +10,9 @@
   <link rel="icon" type="image/x-icon" href="assets/icon/favicon.ico">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#4e8ef7">
- 
+
   <!-- cordova.js required for cordova apps -->
-  <script src="cordova.js"></script>
+  <!-- <script src="cordova.js"></script> -->
 
   <!-- un-comment this code to enable service worker
   <script>


### PR DESCRIPTION
It's a web app only so we don't need Cordova to create a native app. This is slowing down page load pretty significantly, so it's better to get rid of it.

Fixes #19.