### PR TITLE
Print local time with `Date.toString()`

### DIFF
--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -23,7 +23,7 @@ export class HomePage {
 
   selectedLibrary: Library;
   // TODO Update selectedDate to show local US/Pacific time.
-  selectedDate = new Date().toISOString();
+  selectedDate = new Date().toString();
 
   //  TODO Organize mealInventory and tallies into more legible objects.
   mealInventories = [

--- a/src/pages/log/log.ts
+++ b/src/pages/log/log.ts
@@ -25,7 +25,7 @@ export class LogPage {
   libraries: Library[];
   selectedLibrary: Library;
   // TODO Update selectedDate to print local US/Pacific time.
-  selectedDate = new Date().toISOString();
+  selectedDate = new Date().toString();
 
   constructor(public navCtrl: NavController,
               public alertCtrl: AlertController,

--- a/src/pages/report/report.ts
+++ b/src/pages/report/report.ts
@@ -37,8 +37,8 @@ export class ReportPage {
     now = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     var weekAgo = new Date(now.getTime());
     weekAgo.setDate(weekAgo.getDate() - 6);
-    this.endDate = now.toISOString();
-    this.startDate = weekAgo.toISOString();
+    this.endDate = now.toString();
+    this.startDate = weekAgo.toString();
   }
 
   getMeals() {


### PR DESCRIPTION
Make dates more readable (and accurate for end users) by printing PST time instead of UTC time by using `Date.toString()` instead of `Date.toISOString()`.

Example:
```js
> new Date().toISOString()
'2017-05-26T03:40:44.793Z'

> new Date().toString()
'Thu May 25 2017 20:40:48 GMT-0700 (PDT)'
```

Fixes #20.
