### PR TITLE
fix 'undefined' showing up in the error alert after failing validatio…

### DIFF
--- a/src/components/signup/SignupComponent.jsx
+++ b/src/components/signup/SignupComponent.jsx
@@ -51,7 +51,7 @@ class SignupComponent extends React.Component {
     
     validateState = () => {
         var errorMessage = ''
-        errorMessage = validateEmail(this.state.email)
+        errorMessage = validateEmail(this.state.email, '')
         if (this.state.name.length == 0) {
             errorMessage += 'Please enter a valid name\n'
         }


### PR DESCRIPTION
…n of sign up form.

Looks like `validateEmail` expects a string to be passed as the second argument to create the error message.